### PR TITLE
Correct parameter spelling of pf.runtime.http.maxRequestBodySize.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+## 0.6.6 [October 19, 2022]
+- Correct spelling of pf.runtime.http.maxRequestBodySize.
+
 ## 0.6.5 [October 18, 2022]
 - Update some configuration parameter names for Pingfederate 11.
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,7 +46,7 @@ class pingfederate::config inherits ::pingfederate {
       'pf.cluster.diagnostics.enabled'         => $::pingfederate::cluster_diagnostics_enabled,
       'pf.cluster.diagnostics.addr'            => $::pingfederate::cluster_diagnostics_addr,
       'pf.cluster.diagnostics.port'            => $::pingfederate::cluster_diagnostics_port,
-      'pf.runtime.http.max.request.bodysize'   => $::pingfederate::max_request_bodysize,
+      'pf.runtime.http.maxRequestBodySize'     => $::pingfederate::max_request_bodysize,
     }
   }
   create_ini_settings($settings, $defaults)


### PR DESCRIPTION
Sorry, typo. Could this pleased be tagged v0.6.6?