### PR TITLE
Update package names to python3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # CHANGELOG
+## 0.6.8 [May 9, 2025]
+- Update package names for python and libs to python3.
+
 ## 0.6.7 [October 21, 2022]
 - Be more consistent with use of pf.runtime.http.maxRequestBodySize.
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -34,7 +34,7 @@ class pingfederate::install inherits ::pingfederate {
     }
   }
   # python and augeas scripts are in templates/
-  ensure_packages(['python','python-requests','python-libs','augeas'],{'ensure' => 'installed'})
+  ensure_packages(['python3','python3-requests','python3-libs','python3-augeas'],{'ensure' => 'installed'})
 
   # Also install some local configuration tools
   file { "${::pingfederate::install_dir}/local":


### PR DESCRIPTION
This updates some package names to be python3 compatible.
Recommend that this be tagged version 0.6.8 -- Changelog is updated for that.